### PR TITLE
feat: add ShouldContainSameElementsAs assertion for IEnumerable; rout…

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -236,6 +236,8 @@ namespace Shouldly
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string? customMessage = null) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount, string? customMessage = null) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer, string? customMessage = null) { }
+        public static void ShouldContainSameElementsAs<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, string? customMessage = null) { }
+        public static void ShouldContainSameElementsAs<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, System.Collections.Generic.IEqualityComparer<T> comparer, string? customMessage = null) { }
         public static T ShouldHaveSingleItem<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage = null) { }
         public static void ShouldNotBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage = null) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string? customMessage = null) { }

--- a/src/Shouldly.Tests/ShouldContainSameElementsAs/ShouldContainSameElementsAsScenarios.cs
+++ b/src/Shouldly.Tests/ShouldContainSameElementsAs/ShouldContainSameElementsAsScenarios.cs
@@ -1,0 +1,106 @@
+namespace Shouldly.Tests.ShouldContainSameElementsAs;
+
+public class ShouldContainSameElementsAsScenarios
+{
+    [Fact]
+    public void ShouldContainSameElementsAs_ShouldFail() =>
+        Verify.ShouldFail(() =>
+                new List<int> { 1, 4, 2 }.ShouldContainSameElementsAs([1, 2, 3], "Some additional context"),
+
+            errorWithSource:
+            """
+            new List<int> { 1, 4, 2 }
+                should contain same elements as (ignoring order)
+            [1, 2, 3]
+                but
+            new List<int> { 1, 4, 2 }
+                is missing
+            [3]
+                and
+            [1, 2, 3]
+                is missing
+            [4]
+
+            Additional Info:
+                Some additional context
+            """,
+
+            errorWithoutSource:
+            """
+            [1, 4, 2]
+                should contain same elements as (ignoring order)
+            [1, 2, 3]
+                but
+            [1, 4, 2]
+                is missing
+            [3]
+                and
+            [1, 2, 3]
+                is missing
+            [4]
+
+            Additional Info:
+                Some additional context
+            """);
+
+    [Fact]
+    public void ShouldPass() =>
+        new List<int> { 1, 3, 2 }.ShouldContainSameElementsAs([1, 2, 3]);
+
+    [Fact]
+    public void ComparerScenario_ShouldPass() =>
+        new[] { "A", "b" }.ShouldContainSameElementsAs(new[] { "b", "a" }, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Duplicates_WithMatchingCounts_DifferentOrder_ShouldPass() =>
+        new List<int> { 1, 2, 1 }.ShouldContainSameElementsAs([1, 1, 2]);
+
+    [Fact]
+    public void MultiplicityMismatch_ActualHasExtra_ShouldFail() =>
+        Should.Throw<ShouldAssertException>(() =>
+            new List<int> { 1, 1, 2 }.ShouldContainSameElementsAs([1, 2], "Some additional context"));
+
+    [Fact]
+    public void BothEmpty_ShouldPass() =>
+        new List<int>().ShouldContainSameElementsAs(Array.Empty<int>());
+
+    [Fact]
+    public void EmptyActual_ShouldFail() =>
+        Should.Throw<ShouldAssertException>(() =>
+            new List<int>().ShouldContainSameElementsAs([1], "Some additional context"));
+
+    [Fact]
+    public void NullElements_Equal_ShouldPass() =>
+        new string?[] { null, "a" }.ShouldContainSameElementsAs(new string?[] { "a", null });
+
+    [Fact]
+    public void NullPresenceMismatch_ShouldFail() =>
+        Should.Throw<ShouldAssertException>(() =>
+            new string?[] { "a", null }.ShouldContainSameElementsAs(new string?[] { "a" }, "Some additional context"));
+
+    [Fact]
+    public void ComparerMultiplicityMismatch_ShouldFail() =>
+        Should.Throw<ShouldAssertException>(() =>
+            new[] { "a", "A" }.ShouldContainSameElementsAs(new[] { "a" }, StringComparer.OrdinalIgnoreCase, "Some additional context"));
+
+    [Fact]
+    public void LazyEnumerables_ShouldPass()
+    {
+        IEnumerable<int> Yield(params int[] items)
+        {
+            foreach (var i in items) yield return i;
+        }
+
+        Yield(1, 2, 3).ShouldContainSameElementsAs(Yield(3, 2, 1));
+    }
+
+    [Fact]
+    public void NumericSpecials_ShouldPass() =>
+        new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity }
+            .ShouldContainSameElementsAs(new[] { double.NegativeInfinity, double.NaN, double.PositiveInfinity });
+
+    [Fact]
+    public void Regression_ShouldContain_UnchangedGenerator_ShouldFail() =>
+        Should.Throw<ShouldAssertException>(() =>
+            new[] { 1, 2 }.ShouldContain(3, "Some additional context"));
+}

--- a/src/Shouldly/MessageGenerators/ShouldContainMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldContainMessageGenerator.cs
@@ -5,6 +5,7 @@ class ShouldContainMessageGenerator : ShouldlyMessageGenerator
     public override bool CanProcess(IShouldlyAssertionContext context) =>
         context.ShouldMethod.StartsWith("Should", StringComparison.Ordinal)
         && context.ShouldMethod.Contains("Contain")
+        && !context.IgnoreOrder
         && context.Expected is not Expression;
 
     public override string GenerateErrorMessage(IShouldlyAssertionContext context)

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -310,4 +310,17 @@ public static partial class ShouldBeEnumerableTestExtensions
     {
         actual.Select(x => x!.GetType()).ToArray().ShouldBe(expected, customMessage);
     }
+    /// <summary>
+    /// Asserts that the enumerable contains the same elements as the expected enumerable, regardless of order.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ShouldContainSameElementsAs<T>(this IEnumerable<T> actual, IEnumerable<T> expected, string? customMessage = null) =>
+        actual.AssertAwesomelyIgnoringOrder(v => Is.EqualIgnoreOrder(v, expected), actual, expected, customMessage);
+
+    /// <summary>
+    /// Asserts that the enumerable contains the same elements as the expected enumerable, regardless of order, using the specified comparer.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ShouldContainSameElementsAs<T>(this IEnumerable<T> actual, IEnumerable<T> expected, IEqualityComparer<T> comparer, string? customMessage = null) =>
+        actual.AssertAwesomelyIgnoringOrder(v => Is.EqualIgnoreOrder(v, expected, comparer), actual, expected, customMessage);
 }


### PR DESCRIPTION
Adds a new assertion to compare sequences for same elements while ignoring order, with optional comparer support.
Routes ignoring-order failures to the ignoring-order message generator for clearer diffs.
Adds unit tests including duplicates, nulls, lazy sequences, and numeric specials.
Updates the approved public API snapshot.